### PR TITLE
Add Dockerfile for frontend and backend

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,26 @@
+# Use Node.js 20 as base
+FROM node:20-slim
+
+# Create app directory
+WORKDIR /app
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Copy package.json and pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY . .
+
+# Build TypeScript
+RUN pnpm run build
+
+# Expose port
+EXPOSE 3000
+
+# Start the server
+CMD ["node", "dist/index.js"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,5 @@
+# Simple frontend using nginx
+FROM nginx:alpine
+COPY frontend /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -2,3 +2,35 @@
 An OSS deep research server that can run locally and works with email
 
 hello world
+
+## Docker usage
+
+### Backend image
+
+Build the backend image:
+
+```bash
+docker build -f Dockerfile.backend -t glaux-backend .
+```
+
+Run the backend:
+
+```bash
+docker run -p 3000:3000 glaux-backend
+```
+
+### Frontend image
+
+Build the frontend image:
+
+```bash
+docker build -f Dockerfile.frontend -t glaux-frontend .
+```
+
+Run the frontend:
+
+```bash
+docker run -p 8080:80 glaux-frontend
+```
+
+Visit the frontend at `http://localhost:8080`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Glaux Frontend</title>
+  <script>
+    async function fetchGreeting() {
+      const response = await fetch('http://localhost:3000/');
+      const text = await response.text();
+      document.getElementById('greeting').textContent = text;
+    }
+    window.onload = fetchGreeting;
+  </script>
+</head>
+<body>
+  <h1>Glaux Frontend</h1>
+  <div id="greeting">Loading...</div>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 // src/index.ts
 import express from 'express';
+import cors from 'cors';
 
 const app = express();
+app.use(cors());
 const PORT = process.env.PORT || 3000;
 
 app.get('/', (_req, res) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,4 +10,4 @@
     "skipLibCheck": true
   },
   "include": ["src"]
-}{
+}


### PR DESCRIPTION
## Summary
- rename generic Dockerfile to `Dockerfile.backend`
- create `Dockerfile.frontend` using nginx
- provide a minimal static HTML frontend
- allow cross‑origin requests in Express
- update README with new Docker build instructions

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6853b015dec4832895479cc1593a7c91